### PR TITLE
Add Mission Status binding to controller Back button

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -171,6 +171,7 @@ std::pair<WORD, int> g_buttonMappings[] =
 	{ XINPUT_GAMEPAD_DPAD_RIGHT, 21 }, // Lean Right
 	{ XINPUT_GAMEPAD_LEFT_TRIGGER, 81 }, // Throw Grenade
 	{ XINPUT_GAMEPAD_RIGHT_TRIGGER, 17 }, // Fire
+	{ XINPUT_GAMEPAD_BACK, 78 }, // Mission Status
 	{ XINPUT_GAMEPAD_START, -1 }, // Menu
 };
 


### PR DESCRIPTION
This will map the Mission Status/Objectives function to the Back button on the controller. I believe this matches the Xbox 360 functionality according to that version's manual.